### PR TITLE
fw: adiciona mapeamento de pinos (pins.h)

### DIFF
--- a/src/firmware/pins.h
+++ b/src/firmware/pins.h
@@ -1,0 +1,30 @@
+#ifndef PINS_H
+#define PINS_H
+
+// ── I2C ──────────────────────────────────────────────
+#define PIN_I2C_SDA     21 // SDA: Pino de dados para MPU-6500 e VL53L0X (Barramento compartilhado)
+#define PIN_I2C_SCL     22 // SCL: Pino de clock para MPU-6500 e VL53L0X (Barramento compartilhado)
+
+// ── Motores (DRV8833) ─────────────────────────────────
+#define PIN_MOT1_IN1    18 // AIN1: Direção do motor esquerdo (M1)
+#define PIN_MOT1_IN2    19 // AIN2: Direção do motor esquerdo (M1)
+#define PIN_MOT2_IN1    25 // BIN1: Direção do motor direito (M2)
+#define PIN_MOT2_IN2    26 // BIN2: Direção do motor direito (M2)
+// #define PIN_MOT_SLEEP   // A definir: Output digital para sleep do driver
+// #define PIN_MOT_FAULT   // A definir: Input digital para sinalização de falha do driver
+
+// ── Encoders ──────────────────────────────────────────
+#define PIN_ENC1_A      32 // Fase A do encoder do motor esquerdo (com pull-up interno)
+#define PIN_ENC1_B      33 // Fase B do encoder do motor esquerdo (com pull-up interno)
+#define PIN_ENC2_A      34 // Fase A do encoder do motor direito (Input-only, requer pull-up externo 10 KΩ)
+#define PIN_ENC2_B      35 // Fase B do encoder do motor direito (Input-only, requer pull-up externo 10 KΩ)
+
+// ── Sensores ToF (VL53L0X) ────────────────────────────
+#define PIN_TOF1_XSHUT  4  // XSHUT do ToF #1: Ativação seletiva
+#define PIN_TOF2_XSHUT  5  // XSHUT do ToF #2: Ativação seletiva (Strapping pin - cuidado no boot)
+#define PIN_TOF3_XSHUT  15 // XSHUT do ToF #3: Ativação seletiva (Strapping pin - cuidado no boot)
+
+// ── Bateria ───────────────────────────────────────────
+// #define PIN_BAT_ADC     // A definir: Divisor resistivo da bateria (obrigatório usar ADC1 para operar com Wi-Fi)
+
+#endif // PINS_H


### PR DESCRIPTION
---

## Descrição
O que foi feito: Criação do arquivo `src/firmware/pins.h` com o mapeamento centralizado de todos os pinos GPIO utilizados no sistema.

Por que foi necessário: Centralizar as definições de pinos em um único arquivo de configuração facilita a manutenção, evita duplicação e serve de referência única para o firmware, alinhando o código ao esquemático elétrico do projeto.

---
## Issue Relacionada
Tarefa 7.1: Mapear pinos do esquemático no firmware (#100 )
---
## Alterações Realizadas
- Adição do arquivo `src/firmware/pins.h` com defines para I2C (SDA/SCL), motores (AIN1, AIN2, BIN1, BIN2), encoders (fases A/B de M1 e M2) e sensores ToF (XSHUT de três VL53L0X)
- Inclusão de comentários indicando pinos strapping do ESP32 (GPIO5 e GPIO15) que requerem atenção no boot
- Marcação de pinos ainda indefinidos (`PIN_MOT_SLEEP`, `PIN_MOT_FAULT`, `PIN_BAT_ADC`) como pendentes

---
## Como Testar
- [x] Não aplicável
1. Incluir `pins.h` no firmware e verificar que compila sem erros
2. Confirmar que os pinos definidos correspondem ao esquemático elétrico (Figura 7 do relatório)

---
## Checklist
- [x] Issue vinculada corretamente