### PR TITLE
feat: cria endpoint de telemetria e testes automatizados

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -1,0 +1,27 @@
+import logging
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Inicialização do servidor
+app = FastAPI(title="API de Telemetria do Robô")
+
+# Definição do formato do pacote
+class TelemetriaSchema(BaseModel):
+    robo_id: int
+    distancia_mm: int
+    bateria_v: float
+    eixo_x: float
+    eixo_y: float
+    eixo_z: float
+
+# Criação do endpoint POST /telemetria
+@app.post("/telemetria")
+def receber_telemetria(dados: TelemetriaSchema):
+    # Regista no log que o pacote foi recebido 
+    logger.info(f"Pacote válido recebido do Robô {dados.robo_id}: {dados.model_dump()}")
+    
+    # Retorna sucesso 
+    return {"status": "sucesso", "mensagem": "Telemetria registrada com sucesso"}

--- a/src/backend/test_app.py
+++ b/src/backend/test_app.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+from app import app  
+
+client = TestClient(app)
+
+def test_receber_telemetria_valida_ct17():
+    """CT-17: Deve aceitar um pacote de telemetria completo e válido"""
+    payload = {
+        "robo_id": 1,
+        "distancia_mm": 150,
+        "bateria_v": 3.7,
+        "eixo_x": 0.1,
+        "eixo_y": -0.2,
+        "eixo_z": 9.8
+    }
+    response = client.post("/telemetria", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"status": "sucesso", "mensagem": "Telemetria registrada com sucesso"}
+
+def test_receber_telemetria_incompleta_ct18():
+    """CT-18: Deve rejeitar pacotes que não possuem os campos obrigatórios"""
+    payload = {
+        "robo_id": 1
+        # Propositadamente incompleto
+    }
+    response = client.post("/telemetria", json=payload)
+    assert response.status_code == 422  # Erro padrão de validação do FastAPI


### PR DESCRIPTION
## Descrição
<!-- (não editar) Descreva de forma clara o que foi feito e por que foi necessário. -->

<!-- (não editar) PREENCHA ABAIXO -->
**O que foi feito:**
Criação do endpoint de telemetria no backend (`POST /telemetria`) utilizando o framework FastAPI, com validação de tipagem via Pydantic e cobertura de testes automatizados via Pytest.

**Por que foi necessário:**
Para receber, validar e registrar em log os pacotes de dados enviados pelo firmware do robô, garantindo que apenas pacotes completos e estruturados (com ID, dados de bateria e eixos dos sensores) sejam aceitos pelo sistema. A implementação atende diretamente aos critérios de aceitação e aos casos de teste CT-17 e CT-18.

<!-- (não editar) EXEMPLOS
História de Usuário:
O que: Implementação de painel de monitoramento
Por quê: Permitir visualização dos dados em tempo real

Tarefa:
O que: Ajuste na estrutura de suporte
Por quê: Garantir maior estabilidade do sistema
-->

---

## Issue Relacionada

<!-- (não editar) PREENCHA ABAIXO -->
Receber Telemetria no Backend (#7.11)


---

## Alterações Realizadas

<!-- (não editar) Liste objetivamente as principais mudanças. -->

<!-- (não editar) PREENCHA ABAIXO -->
- Criação do arquivo `src/backend/app.py` contendo a instância do servidor FastAPI e configuração de logs.
- Definição do modelo `TelemetriaSchema` (Pydantic) para validação estrita dos campos obrigatórios da telemetria.
- Implementação da rota `POST /telemetria` para processamento e retorno de códigos HTTP (200 OK / 422 Unprocessable Entity).
- Criação do arquivo `src/backend/test_app.py` com a suíte de testes unitários validando os cenários de sucesso e falha (CT-17 e CT-18).

<!-- (não editar) EXEMPLOS
História de Usuário:
- Criação de interface de visualização
- Integração com fonte de dados

Tarefa:
- Reforço de componente estrutural
- Atualização de documentação técnica
-->

---

## Como Testar

<!-- (não editar) Descreva os passos para validação das alterações. -->

<!-- (não editar) PREENCHA ABAIXO -->
- [ ] Não aplicável

1. Acessar a pasta raiz do projeto e certificar-se de que o ambiente virtual está ativo e o framework instalado (`pip install fastapi pytest httpx pydantic`).
2. Navegar até o diretório do backend (`cd src/backend`).
3. Executar o comando `pytest` no terminal.
4. Verificar se os testes de validação de telemetria passam com a mensagem verde de sucesso no terminal (`2 passed`).

<!-- (não editar) EXEMPLOS
História de Usuário:
1. Acessar o sistema
2. Verificar se os dados são exibidos corretamente

Tarefa:
1. Inspecionar o componente ajustado
2. Validar funcionamento conforme esperado
-->

---

## Checklist

- [x] Alterações testadas
- [x] Issue vinculada corretamente