### PR TITLE
Fw/receber comandos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,7 +367,6 @@ TSWLatexianTemp*
 .pio/
 include/
 lib/
-test/
 
 # Banco SQLite
 db/*.db

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,3 +15,5 @@ lib_deps =
   pololu/VL53L0X @ ^1.3.1
   adafruit/Adafruit MPU6050 @ ^2.2.6
   adafruit/Adafruit Unified Sensor @ ^1.1.14
+  bblanchon/ArduinoJson @ ^7.0.4
+  links2004/WebSockets @ ^2.4.1

--- a/src/firmware/network/network.cpp
+++ b/src/firmware/network/network.cpp
@@ -1,0 +1,37 @@
+#include "network.h"
+#include <ArduinoJson.h>
+
+// Inicializa o estado padrão (necessário por ser uma variável estática)
+String RobotNetwork::currentState = "desconectado";
+
+void RobotNetwork::processCommand(String payload) {
+    // Cria o documento JSON (Sintaxe oficial do ArduinoJson v7)
+    JsonDocument doc;
+    
+    // Tenta ler e converter a string recebida
+    DeserializationError error = deserializeJson(doc, payload);
+
+    // Se a mensagem não for um JSON válido, vai para estado de erro
+    if (error) {
+        currentState = "error";
+        return;
+    }
+
+    // Extrai o valor associado à chave "comando"
+    const char* comando = doc["comando"];
+
+    if (comando != nullptr) {
+        // Verifica se o comando é o "conectar" exigido no critério da issue
+        if (strcmp(comando, "conectar") == 0) {
+            currentState = "connected"; 
+        } 
+        // Se for um comando desconhecido (como o "voar" do nosso teste)
+        else {
+            currentState = "error"; 
+        }
+    } 
+    // Se for um JSON válido, mas que não tem a palavra "comando" dentro dele
+    else {
+        currentState = "error"; 
+    }
+}

--- a/src/firmware/network/network.h
+++ b/src/firmware/network/network.h
@@ -1,0 +1,16 @@
+#ifndef NETWORK_H
+#define NETWORK_H
+
+#include <Arduino.h>
+
+// Classe responsável por interpretar os comandos do Backend
+class RobotNetwork {
+public:
+    // Variável estática para guardar o estado atual do robô
+    static String currentState;
+
+    // Função que recebe a mensagem WebSocket e decide o que fazer
+    static void processCommand(String payload);
+};
+
+#endif

--- a/test/test_network/test_network.cpp
+++ b/test/test_network/test_network.cpp
@@ -1,0 +1,36 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#include "network/network.h" 
+
+void setUp(void) {
+    // Redefine o estado antes de cada teste
+    RobotNetwork::currentState = "desconectado";
+}
+
+void tearDown(void) {
+    // Limpeza após o teste
+}
+
+void test_receber_comando_conectar() {
+    String payload = "{\"comando\":\"conectar\"}";
+    RobotNetwork::processCommand(payload);
+    TEST_ASSERT_EQUAL_STRING("connected", RobotNetwork::currentState.c_str());
+}
+
+void test_receber_comando_invalido() {
+    String payload = "{\"comando\":\"voar\"}";
+    RobotNetwork::processCommand(payload);
+    TEST_ASSERT_EQUAL_STRING("error", RobotNetwork::currentState.c_str());
+}
+
+void setup() {
+    delay(2000); 
+    UNITY_BEGIN();
+    RUN_TEST(test_receber_comando_conectar);
+    RUN_TEST(test_receber_comando_invalido);
+    UNITY_END();
+}
+
+void loop() {
+}


### PR DESCRIPTION
## Descrição
**O que foi feito:**
Criação do módulo de rede (`network.h` e `network.cpp`) no firmware do ESP32 para receber e processar comandos JSON vindos do Backend via WebSockets. A implementação foi guiada por testes (TDD) com a criação de uma suíte de testes unitários (`test_network`).

**Por que foi necessário:**
Para permitir que o robô (ESP32) atue como um agente ativo, capaz de interpretar comandos externos (como `{"comando":"conectar"}`) e atualizar seu estado interno, cumprindo os critérios de aceitação da tarefa de comunicação bidirecional com o servidor.

---

## Issue Relacionada

- Closes #183 

---

## Alterações Realizadas

- Adição das dependências `ArduinoJson` e `WebSockets` no arquivo `platformio.ini`.
- Criação da suíte de testes unitários `test/test_network/test_network.cpp` para validar os estados de conexão e erro.
- Implementação da classe `RobotNetwork` (`src/firmware/network/`) responsável por desserializar o payload JSON e gerenciar o `currentState` do robô.

---

## Como Testar

- [ ] Não aplicável

1. Abrir o projeto no VS Code com a extensão do PlatformIO instalada.
2. Abrir o terminal do PlatformIO (`PlatformIO Core CLI`).
3. Executar o comando `pio run -e esp32dev` (para validar a compilação de todo o firmware) ou