### PR TITLE
Feat/comandos backend

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -149,8 +149,8 @@ async def encaminhar_para_esp32(comando: str) -> bool:
  
 @app.post("/comandos")
 async def receber_comando(payload: ComandoSchema):
-    # Recebe um comando validado do Frontend e tenta enviá-lo ao ESP32.
-    # Chama a função que tenta enviar a mensagem
+    #Recebe um comando validado do Frontend e tenta enviá-lo ao ESP32.
+    # Chama a função que tenta enviar a mensagem ao robô
     sucesso = await encaminhar_para_esp32(payload.comando)
     
     if sucesso:
@@ -158,11 +158,12 @@ async def receber_comando(payload: ComandoSchema):
             "status": "comando_enviado", 
             "comando": payload.comando
         }
-    else:
-        return {
-            "status": "erro_encaminhamento", 
-            "comando": payload.comando
-        }
+    
+    # Se o robô não responder ou falhar, lança o erro 503 correto
+    raise HTTPException(
+        status_code=503, 
+        detail="Falha de comunicação com o ESP32 (Timeout/Offline)"
+    )
 
 
 if __name__ == "__main__":

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -3,6 +3,8 @@ import math
 from typing import Optional
 from fastapi import FastAPI, Query, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from typing import Literal
+from schemas.comandos import ComandoSchema
 
 from database.database import init_db, salvar_corrida, listar_corridas, buscar_corrida, limpar_banco
 from memory.session_buffer import (
@@ -140,6 +142,13 @@ def apagar_historico():
     except Exception as e:
         logger.error(f"Erro ao limpar banco: {e}")
         raise HTTPException(status_code=500, detail="Erro ao limpar histórico")
+    
+@app.post("/comandos")
+async def receber_comando(payload: ComandoSchema):
+    return {
+        "status": "comando_recebido", 
+        "comando": payload.comando
+    }
 
 
 if __name__ == "__main__":

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -142,13 +142,27 @@ def apagar_historico():
     except Exception as e:
         logger.error(f"Erro ao limpar banco: {e}")
         raise HTTPException(status_code=500, detail="Erro ao limpar histórico")
-    
+
+async def encaminhar_para_esp32(comando: str) -> bool:
+    # TODO: Implementar lógica real de rede para o ESP32
+    return True
+ 
 @app.post("/comandos")
 async def receber_comando(payload: ComandoSchema):
-    return {
-        "status": "comando_recebido", 
-        "comando": payload.comando
-    }
+    # Recebe um comando validado do Frontend e tenta enviá-lo ao ESP32.
+    # Chama a função que tenta enviar a mensagem
+    sucesso = await encaminhar_para_esp32(payload.comando)
+    
+    if sucesso:
+        return {
+            "status": "comando_enviado", 
+            "comando": payload.comando
+        }
+    else:
+        return {
+            "status": "erro_encaminhamento", 
+            "comando": payload.comando
+        }
 
 
 if __name__ == "__main__":

--- a/src/backend/pytest.ini
+++ b/src/backend/pytest.ini
@@ -2,6 +2,7 @@
 testpaths = tests
 python_files = test_*.py
 python_functions = test_*
+pythonpath = .
 addopts =
     --cov=.
     --cov-report=term-missing

--- a/src/backend/schemas/comandos.py
+++ b/src/backend/schemas/comandos.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+from typing import Literal
+
+class ComandoSchema(BaseModel):
+    # Aceita apenas os comandos mapeados na nossa arquitetura
+    comando: Literal["conectar", "iniciar"]

--- a/src/backend/tests/test_comandos.py
+++ b/src/backend/tests/test_comandos.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-
+from unittest.mock import patch
 from app import app 
 
 client = TestClient(app)
@@ -12,7 +12,7 @@ def test_receber_comando_conectar_sucesso():
     
     # Espera que a rota processe e aceite o formato
     assert response.status_code == 200
-    assert response.json()["status"] == "comando_recebido"
+    assert response.json()["status"] == "comando_enviado"
 
 def test_receber_comando_invalido():
     # Envia um comando não suportado pelo sistema
@@ -21,3 +21,18 @@ def test_receber_comando_invalido():
     
     # Espera erro de validação (422 Unprocessable Entity) do Pydantic
     assert response.status_code == 422
+
+# O @patch substitui a função real por um "espião" durante o teste
+@patch("app.encaminhar_para_esp32")
+def test_encaminhamento_ao_esp32(mock_encaminhar):
+    # Simula que a função de envio retornou Sucesso (True)
+    mock_encaminhar.return_value = True
+    
+    payload = {"comando": "iniciar"}
+    response = client.post("/comandos", json=payload)
+    
+    assert response.status_code == 200
+    assert response.json()["status"] == "comando_enviado"
+    
+    # Verifica se a rota chamou a função de encaminhar passando a string "iniciar"
+    mock_encaminhar.assert_called_once_with("iniciar")

--- a/src/backend/tests/test_comandos.py
+++ b/src/backend/tests/test_comandos.py
@@ -36,3 +36,15 @@ def test_encaminhamento_ao_esp32(mock_encaminhar):
     
     # Verifica se a rota chamou a função de encaminhar passando a string "iniciar"
     mock_encaminhar.assert_called_once_with("iniciar")
+
+@patch("app.encaminhar_para_esp32")
+def test_encaminhamento_falha_esp32_offline(mock_encaminhar):
+    # Simula que o ESP32 está desligado ou deu timeout
+    mock_encaminhar.return_value = False
+    
+    payload = {"comando": "iniciar"}
+    response = client.post("/comandos", json=payload)
+    
+    # Espera que a API retorne o erro 503 (Serviço Indisponível)
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Falha de comunicação com o ESP32 (Timeout/Offline)"

--- a/src/backend/tests/test_comandos.py
+++ b/src/backend/tests/test_comandos.py
@@ -1,0 +1,23 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app import app 
+
+client = TestClient(app)
+
+def test_receber_comando_conectar_sucesso():
+    # Frontend enviando um payload válido para o Backend
+    payload = {"comando": "conectar"}
+    response = client.post("/comandos", json=payload)
+    
+    # Espera que a rota processe e aceite o formato
+    assert response.status_code == 200
+    assert response.json()["status"] == "comando_recebido"
+
+def test_receber_comando_invalido():
+    # Envia um comando não suportado pelo sistema
+    payload = {"comando": "voar"}
+    response = client.post("/comandos", json=payload)
+    
+    # Espera erro de validação (422 Unprocessable Entity) do Pydantic
+    assert response.status_code == 422


### PR DESCRIPTION
## Descrição
**O que foi feito:**
Criação de uma nova rota no Backend (`POST /comandos`) com validação estrita de payload via Pydantic, função assíncrona base de encaminhamento ao ESP32 e tratamento de exceções (HTTP 503) para cenários de falha. Todo o desenvolvimento foi guiado por testes (TDD) atingindo a cobertura total dos cenários esperados.

**Por que foi necessário:**
Para que o Backend possa atuar como intermediário seguro entre o Dashboard (Frontend) e o ESP32, garantindo que apenas comandos válidos ("conectar", "iniciar") cheguem ao robô, além de prover feedback correto ao Frontend caso o microcontrolador esteja offline ou não responda (timeout).

---

## Issue Relacionada

Tarefa 7.29: Criar rota de envio de comandos ao ESP32 no Backend (#184 )

---

## Alterações Realizadas

- Criação do modelo de validação `ComandoSchema` em `src/backend/schemas/comandos.py`.
- Implementação da rota `POST /comandos` e da função base `encaminhar_para_esp32` no arquivo `src/backend/app.py`.
- Adição de lançamento de erro HTTP 503 (Service Unavailable) em caso de falha de comunicação com o robô.
- Criação de suíte de testes (`src/backend/tests/test_comandos.py`) utilizando a biblioteca `unittest.mock` para validar o repasse das chamadas.

---

## Como Testar

- [ ] Não aplicável

1. Fazer o checkout para a branch e garantir que o ambiente virtual Python (`.venv`) está ativo.
2. Navegar até a pasta raiz do backend (`src/backend`).
3. Executar o comando: `pytest tests/test_comandos.py`
4. Confirmar que os 4 testes passam com sucesso, indicando que o roteamento, a validação de schema e os tratamentos de erro estão funcionais.

---

## Checklist

- [x] Alterações testadas
- [x] Issue vinculada corretamente