### PR TITLE
docs: atualiza caminho da documentação de comunicação com ESP32

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,7 @@ nav:
   - Software:
       - Visão Geral: software/software.md
       - Protótipo Funcional da Interface: software/prototipo_interface.md
-      - ADR-001 Comunicação de Comandos (ESP32): software/adr-001-comunicacao-comandos-esp32.md
+      - ADR-001 Comunicação de Comandos (ESP32): software/comunicacao-comandos-esp32.md
       - Requisitos e Backlog:
           - Backlog do Produto: software/entrega_1/backlog_produto.md
       - Modelagem e Fluxos:


### PR DESCRIPTION
## O que foi feito
Corrigido o caminho do documento ADR-001 no arquivo `mkdocs.yml`.

## Motivação
Garantir que o ADR seja exibido corretamente na documentação gerada pelo MkDocs.

## Impacto
Apenas ajuste na navegação da documentação, sem alterações de código ou regras de negócio.