### PR TITLE
Docs/limite-telemetria

### DIFF
--- a/docs/software/entrega_1/matriz_testes_funcionais.md
+++ b/docs/software/entrega_1/matriz_testes_funcionais.md
@@ -623,20 +623,20 @@ Os testes não-funcionais explicitam critérios mensuráveis de desempenho, capa
 | **Reparo** | Corrigir broadcast, filas assíncronas ou limites de conexão. |
 | **Pós-Reparo** | Reexecutar teste com 10 clientes por 60 segundos. |
 
-### CT-39 — Tamanho do Pacote de Telemetria
+**CT-39 — Tamanho do Pacote de Telemetria**
 
 | Atributo | Descrição |
-|---|---|
-| **Objetivo** | Verificar se o pacote de telemetria tem no máximo 512 bytes. |
+| :--- | :--- |
+| **Objetivo** | Verificar se os pacotes da transmissão contínua respeitam o limite de 512 bytes. O pacote de finalização é exceção documentada (RNF-09) e não está sujeito ao limite. |
 | **Requisito(s) coberto(s)** | RNF-09; RF-08 / US08; RF-09 / US09 |
 | **Técnica de teste** | Análise de fronteira de tamanho |
-| **Partições e fronteiras** | Mínimo, típico, completo 16x16; 511, 512 e 513 bytes. |
-| **Casos concretos** | Pacote mínimo, pacote típico e pacote completo 16x16. |
-| **Pré-condições** | Serializador de telemetria disponível no firmware, simulador ou backend. |
-| **Procedimentos** | 1. Serializar pacote mínimo.<br>2. Serializar pacote típico.<br>3. Serializar pacote completo 16x16.<br>4. Medir tamanho em bytes.<br>5. Testar rejeição de pacote acima do limite. |
-| **Resultado Esperado** | Pacotes válidos têm no máximo 512 bytes; pacote acima do limite é rejeitado. |
-| **Reparo** | Reduzir campos, compactar representação ou ajustar validação de tamanho. |
-| **Pós-Reparo** | Reexecutar medição dos três pacotes e rejeição acima do limite. |
+| **Partições e fronteiras** | Transmissão contínua: mínimo, típico e máximo; fronteiras em 511, 512 e 513 bytes. Pacote de finalização: registrado apenas para referência, fora da partição do limite. Escopo: labirintos 4x4 e 8x8. |
+| **Casos concretos** | Pacote mínimo (`running`, 1º passo), típico (`running`, meio da corrida) e máximo da transmissão contínua nos labirintos 4x4 e 8x8; pacote de finalização completo (`path_traversed` + `known_walls`) registrado para referência. |
+| **Pré-condições** | `scripts/fake_robot.py` disponível e funcional; serializador de telemetria acessível. |
+| **Procedimentos** | 1. Serializar pacote `running` mínimo e registrar tamanho. 2. Serializar pacote `running` típico e registrar tamanho. 3. Serializar pacote `running` máximo nos labirintos 4x4 e 8x8 e validar ≤ 512 bytes. 4. Serializar o pacote de finalização completo nos mesmos labirintos e registrar o tamanho sem aplicar o limite. 5. Verificar que pacotes contínuos acima de 512 bytes são rejeitados pelo backend. |
+| **Resultado Esperado** | Todos os pacotes com `race_status` diferente de `finished` têm no máximo 512 bytes. O pacote de finalização pode exceder esse limite sem rejeição. Pacotes contínuos acima do limite são rejeitados. |
+| **Reparo** | Reduzir campos ou compactar representação — aplicável apenas aos pacotes da transmissão contínua. |
+| **Pós-Reparo** | Reexecutar os passos 3 e 5. |
 
 ### CT-40 — Integridade Somente-Leitura
 

--- a/docs/software/entrega_1/requisitos_nao_funcionais.md
+++ b/docs/software/entrega_1/requisitos_nao_funcionais.md
@@ -112,6 +112,8 @@ O contexto mais exigente é a apresentação final, na qual professores avaliado
 
 Microcontroladores tipicamente utilizados em projetos Micromouse (como STM32 ou ESP32) possuem buffers de comunicação limitados. Pacotes menores reduzem também a latência de transmissão e o risco de fragmentação na rede. Os dados necessários por ciclo (posição, velocidade, nível de bateria e data_hora) podem ser representados em menos de 100 bytes com estrutura binária eficiente. O limite de 512 bytes é generoso o bastante para acomodar inclusive formatos textuais como JSON, mais convenientes para depuração durante o desenvolvimento.
 
+> O pacote de finalização trafega fora da cadência de 1 Hz e contém campos de tamanho variável dependentes do labirinto (`path_traversed` e `known_walls`); por isso é tratado como exceção. O limite de 512 bytes aplica-se exclusivamente aos pacotes da transmissão contínua.
+
 ## 4. Segurança
 
 ### RNF-10 — Integridade dos Dados de Corrida

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
       - ADR-001 Comunicação de Comandos (ESP32): software/comunicacao-comandos-esp32.md
       - Requisitos e Backlog:
           - Backlog do Produto: software/entrega_1/backlog_produto.md
+          - Requisitos Não-Funcionais: software/entrega_1/requisitos_nao_funcionais.md
       - Modelagem e Fluxos:
           - Diagrama de Atividades: software/entrega_1/diagrama_atividades.md
           - Casos de Uso: software/entrega_1/diagrama_casos_uso.md

--- a/src/contrato_telemetria.md
+++ b/src/contrato_telemetria.md
@@ -37,14 +37,16 @@ Para garantir a fidelidade da visualização no dashboard, o fluxo de dados deve
 
 A persistência dos dados é **diferida**: os pacotes recebidos durante a corrida são mantidos **exclusivamente em memória** (buffer de sessão no backend) e **não são gravados no banco de dados** enquanto `race_status` for `running` ou `paused`.
 
-A gravação no banco de dados ocorre **uma única vez**, de forma atômica, quando o backend recebe um pacote com `race_status = "finished"` ou o evento `race_ended`. **O pacote de finalização deve obrigatoriamente incluir o `path_traversed` completo** com todas as coordenadas `{x, y, z}` percorridas desde o início da corrida — é a partir dele que o backend persiste o trajeto integral. Nesse momento, o backend consolida o buffer de sessão, calcula os dados derivados (tempo total, velocidade média, consumo de bateria) e persiste o registro completo da corrida.
+A gravação no banco de dados ocorre **uma única vez**, de forma atômica, quando o backend recebe um pacote com `race_status = "finished"` ou o evento `race_ended`. **O pacote de finalização deve obrigatoriamente incluir o `path_traversed` completo** com todas as coordenadas `{x, y, z}` percorridas desde o início da corrida, além do `known_walls` (mapa de paredes completo) — é a partir desses dois campos que o backend persiste o trajeto integral e o mapa da corrida. Nesse momento, o backend consolida o buffer de sessão, calcula os dados derivados (tempo total, velocidade média, consumo de bateria) e persiste o registro completo da corrida.
+
+> O limite de 512 bytes do RNF-09 aplica-se exclusivamente aos pacotes da transmissão contínua (seção 2.1). O pacote de finalização é uma exceção documentada: por ser enviado uma única vez, ao término da corrida, em rede local, pode incluir `path_traversed` e `known_walls` completos sem restrição de tamanho.
 
 Em caso de `race_status = "error"`, o buffer de sessão é descartado e **nenhum dado é persistido**.
 
 | Situação | Ação do Backend |
 | :--- | :--- |
 | `race_status = "running"` ou `"paused"` | Repassa ao dashboard via stream; armazena em buffer de memória. |
-| `race_status = "finished"` / evento `race_ended` | Persiste o registro completo no banco (exige `path_traversed` completo); limpa o buffer. |
+| `race_status = "finished"` / evento `race_ended` | Persiste o registro completo no banco (exige `path_traversed` e `known_walls` completos; pacote isento do limite de 512 B do RNF-09); limpa o buffer. |
 | `race_status = "error"` | Descarta o buffer; nenhuma escrita no banco. |
 
 ## 3. Eventos Especiais e Mensagens
@@ -151,7 +153,7 @@ Paredes do **perímetro** devem ser marcadas como `true` (`x=0` ⇒ `[3]=true`, 
 
 ## 7. Exemplo de Pacote de Finalização (Dispara Persistência)
 
-O pacote abaixo exemplifica a mensagem que encerra a corrida e aciona a gravação no banco de dados.
+O pacote abaixo exemplifica a mensagem que encerra a corrida e aciona a gravação no banco de dados. É a única mensagem do protocolo isenta do limite de 512 bytes do RNF-09 (decisão D9) — por isso traz o `path_traversed` completo e, opcionalmente, o `known_walls` (omitido aqui por brevidade; ver seção 6).
 
 ```json
 {
@@ -179,9 +181,9 @@ O pacote abaixo exemplifica a mensagem que encerra a corrida e aciona a gravaç�
     "x": 120.5,
     "y": 45.0,
     "z": 9.81
-  }
+  },
+  "known_walls": [ "...matriz completa de paredes," ]
 }
 ```
-
 
 


### PR DESCRIPTION
## Descrição
O que foi feito: Resolução da divergência D9 — o limite de 512 bytes do RNF-09 foi restrito aos pacotes da transmissão contínua, com o pacote de finalização documentado como exceção. O CT-39 foi ajustado para refletir o novo escopo, e o contrato de telemetria foi simplificado na seção 2.2.

Por que foi necessário: O RNF-09 e o contrato de telemetria eram contraditórios: o primeiro limitava todo pacote a 512 bytes, enquanto o segundo exigia que o pacote de finalização trouxesse `path_traversed` e `known_walls` completos — campos que isoladamente já superam esse limite a partir do labirinto 8x8. A decisão desbloqueia a Tarefa #197 (Tarefa 7.40: Conectar o robô no Wi-Fi e enviar os dados da corrida para o sistema web).

## Issue Relacionada
Tarefa 7.43: Decidir o limite de tamanho do pacote de telemetria (contradição RNF-09 × contrato) (#200)

## Alterações Realizadas
- `RNF-09`: limite de 512 bytes restrito à transmissão contínua; pacote de finalização documentado como exceção
- `CT-39`: escopo do teste ajustado para excluir o pacote de finalização do limite; tamanho do pacote final registrado apenas para referência
- `contrato_telemetria.md` (seção 2.2): bloco de justificativa com métricas removido; regra e exceção mantidas de forma concisa
- `mkdocs.yml`: adicionada aba de Requisitos Não-Funcionais à navegação

## Checklist
- [x] Alterações testadas
- [x] Issue vinculada corretamente



Co-authored-by: Flavia Rebelato <[melorebelato@outlook.com](mailto:melorebelato@outlook.com)>